### PR TITLE
change update aws provider to 6.0.0

### DIFF
--- a/c1-01-versions.tf
+++ b/c1-01-versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.93.0"
+      version = ">= 6.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/c1-01-versions.tf
+++ b/c1-01-versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated AWS provider requirement to v6-compatible constraint.
  * Aligns infrastructure tooling with newer AWS provider capabilities and fixes.
  * No runtime/functional changes expected; existing deployments should behave the same.
  * Users should run terraform init to fetch the updated provider versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->